### PR TITLE
[TypoFix] Change phpcs path in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ $ php phpcs-tool.phar install symfony/Symfony2
 Show available code sniffer with phpcs command
 
 ```bash
-$ ~/.php-code-sniffer-tool/vendor/bin/phpcs -i
+$ ~/.php-code-sniffer-tool/bin/phpcs -i
 ```


### PR DESCRIPTION
```phpcs``` lying under the "install directory"
according to https://github.com/LeoOnTheEarth/php-code-sniffer-tool/blob/master/main.php#L176